### PR TITLE
Change homepage's hero to full screen height on desktop viewports.

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -6,11 +6,12 @@ type HeroProps = {
   imgSrc: StaticImageData | string;
   width?: number;
   height?: number;
+  home?: boolean;
 };
 
-const Hero = ({ children, imgSrc, width, height }: HeroProps) => {
+const Hero = ({ children, imgSrc, width, height, home }: HeroProps) => {
   return (
-    <header className={styles.hero}>
+    <header className={home ? styles.homeHero : styles.hero}>
       <div className={styles.heroContent}>{children}</div>
       {typeof imgSrc === "string" ? (
         <Image

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -89,7 +89,7 @@ const Home: NextPage<PageProps> = ({ trips, articles }) => {
       </Head>
 
       <main>
-        <Hero imgSrc={heroImg}>
+        <Hero imgSrc={heroImg} home={true}>
           <h1>THE TRAVEL ENABLERS</h1>
           <span>How can we enable you?</span>
           <Divider />

--- a/styles/Hero.module.scss
+++ b/styles/Hero.module.scss
@@ -1,6 +1,64 @@
 @use "variables" as v;
 
 @media all and (min-width: 0) {
+
+  .homeHero {
+    height: 100vh;
+    color: v.$white;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    position: relative;
+    overflow: hidden;
+
+    span {
+      font-size: 1.2rem;
+    }
+    svg {
+      margin-block: 10px;
+      width: 150px;
+    }
+    .heroContent {
+      width: 100%;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      padding: 0 5%;
+      margin-top: 20px;
+    }
+
+    a {
+      margin-top: 5px;
+    }
+
+    &::before {
+      content: "";
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+      background-color: v.$black;
+      z-index: -1;
+      opacity: 0.5;
+    }
+    .img {
+      width: 100%;
+      height: 100%;
+      position: relative;
+      z-index: -2;
+      display: block;
+      object-fit: cover;
+      overflow: hidden;
+    }
+  }
+  
   .hero {
     height: 63.3vw;
     color: v.$white;
@@ -60,6 +118,16 @@
 }
 
 @media all and (min-width: v.$tablet) {
+  .homeHero {
+    span {
+      font-size: 1.5rem;
+    }
+
+    svg {
+      width: 200px;
+    }
+  }
+
   .hero {
     height: 43.3vw;
     span {
@@ -72,6 +140,21 @@
 }
 
 @media all and (min-width: v.$desktop) {
+
+  .homeHero {
+    span {
+      font-size: 2rem;
+    }
+
+    svg {
+      width: 250px;
+    }
+    
+    a {
+      margin-top: 20px;
+    }
+  }
+
   .hero {
     height: 40.7vw;
     align-items: center;

--- a/styles/Hero.module.scss
+++ b/styles/Hero.module.scss
@@ -1,65 +1,7 @@
 @use "variables" as v;
 
 @media all and (min-width: 0) {
-
-  .homeHero {
-    height: 100vh;
-    color: v.$white;
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    position: relative;
-    overflow: hidden;
-
-    span {
-      font-size: 1.2rem;
-    }
-    svg {
-      margin-block: 10px;
-      width: 150px;
-    }
-    .heroContent {
-      width: 100%;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      text-align: center;
-      padding: 0 5%;
-      margin-top: 20px;
-    }
-
-    a {
-      margin-top: 5px;
-    }
-
-    &::before {
-      content: "";
-      display: block;
-      position: absolute;
-      top: 0;
-      left: 0;
-      height: 100%;
-      width: 100%;
-      background-color: v.$black;
-      z-index: -1;
-      opacity: 0.5;
-    }
-    .img {
-      width: 100%;
-      height: 100%;
-      position: relative;
-      z-index: -2;
-      display: block;
-      object-fit: cover;
-      overflow: hidden;
-    }
-  }
-  
-  .hero {
+  .hero, .homeHero {
     height: 63.3vw;
     color: v.$white;
     display: flex;
@@ -142,6 +84,7 @@
 @media all and (min-width: v.$desktop) {
 
   .homeHero {
+    height: 100vh;
     span {
       font-size: 2rem;
     }
@@ -149,7 +92,7 @@
     svg {
       width: 250px;
     }
-    
+
     a {
       margin-top: 20px;
     }


### PR DESCRIPTION
Added optional prop to hero component to render at full screen height, which is only applicable to desktop viewports, as full-screen looks very odd on mobile and tablet.